### PR TITLE
Initial build for 0.22.0 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,77 @@
+{% set name = "pysam" %}
+{% set version = "0.22.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/pysam-developers/pysam/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 61b3377c5f889ddc6f6979912c3bb960d7e08407dada9cb38f13955564ea036f
+  patches:
+    - patches/0001-Unvendor-deps.patch
+
+build:
+  number: 0
+  # https://github.com/samtools/htslib/issues/86
+  skip: True  # [win]
+  script_env:
+    # This is the default, but it's preferable to be explicit.
+    - HTSLIB_MODE=shared
+  script:
+    # Delete samtools/lz4 just to make sure they are not used/compiled by accident.
+    - rm -rf samtools/lz4
+    - {{ PYTHON }} -m pip install . -v --no-build-isolation --no-deps
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - patch
+    - make
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+    - cython >=3
+    # These are required for the vendored htslib.
+    - libcurl 8
+    - bzip2 {{ bzip2 }}
+    - xz {{ xz }}
+    - libdeflate 1.17
+    # Only required for libcrypto.
+    # On macOS, links to libSystem
+    - openssl  {{ openssl }}  # [linux]
+    - lz4-c 1.9
+    # These are required for the vendored htslib, bcftools and samtools.
+    - zlib {{ zlib }}
+  run:
+    - python
+    - lz4-c  # pin through run_exports
+    - {{ pin_compatible('libcurl') }}
+    - bzip2  # pin through run_exports
+    - xz  # pin through run_exports
+    - zlib  # pin through run_exports
+    - openssl  # [linux]
+    - libdeflate  # pin through run_exports
+
+test:
+  imports:
+    - pysam
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/pysam-developers/pysam
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: Pysam is a Python package for reading, manipulating, and writing genomics data such as SAM/BAM/CRAM and VCF/BCF files. It's a lightweight wrapper of the HTSlib API, the same one that powers samtools, bcftools, and tabix.
+  description: >
+    Pysam is a python module for reading and manipulating files in the SAM/BAM format.
+    The SAM/BAM format is a way to store efficiently large numbers of alignments (Li 2009),
+    such as those routinely created by next-generation sequencing methods.
+  dev_url: https://github.com/pysam-developers/pysam
+  doc_url: https://pysam.readthedocs.io

--- a/recipe/patches/0001-Unvendor-deps.patch
+++ b/recipe/patches/0001-Unvendor-deps.patch
@@ -1,0 +1,74 @@
+From ea2cc90121095b030c3c92d087df3436d79087e0 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Morin <jcmorin@anaconda.com>
+Date: Fri, 2 Feb 2024 13:51:49 -0500
+Subject: [PATCH] Unvendor lz4 and compile a dynalic htslib instead of static.
+
+Note that we don't unvendor samtools and bcftools because they are modified from upstream
+and we can't unvendor them. As for htslib, it was considered unnecessary to unvendor
+since its version is tightly coupled with pysam, bcftools and samtools.
+
+---
+ setup.py | 20 ++++++++++++--------
+ 1 file changed, 12 insertions(+), 8 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index a4bf36d..c4c43da 100644
+--- a/setup.py
++++ b/setup.py
+@@ -474,6 +474,9 @@ elif HTSLIB_MODE == 'shared':
+     # all object files are pulled into the link, even those not used by htslib itself.
+     htslib_objects = [os.path.join("htslib", x)
+                       for x in htslib_make_options["LIBHTS_OBJS"].split(" ")]
++    if platform.system() == "Linux":
++        # Objects on Linux are named .pico instead of .o when running "make lib-shared"...
++        htslib_objects = [x.replace(".o", ".pico") for x in htslib_objects]
+     separate_htslib_objects = []
+ 
+     htslib_library_dirs = ["."] # when using setup.py develop?
+@@ -566,15 +569,16 @@ def prebuild_libchtslib(ext, force):
+ 
+     write_configvars_header("htslib/config_vars.h", ext, "HTS")
+ 
+-    if force or not os.path.exists("htslib/libhts.a"):
+-        log.info("building 'libhts.a'")
++    shlib_ext = os.environ["SHLIB_EXT"]
++    if force or not os.path.exists("htslib/libhts{0}".format(shlib_ext)):
++        log.info("building 'libhts{0}'".format(shlib_ext))
+         with changedir("htslib"):
+             # TODO Eventually by running configure here, we can set these
+             # extra flags for configure instead of hacking on ALL_CPPFLAGS.
+             args = " ".join(ext.extra_compile_args)
+-            run_make(["ALL_CPPFLAGS=-I. " + args + " $(CPPFLAGS)", "lib-static"])
++            run_make(["ALL_CPPFLAGS=-I. " + args + " $(CPPFLAGS)", "lib-shared"])
+     else:
+-        log.warning("skipping 'libhts.a' (already built)")
++        log.warning("skipping 'libhts{0}' (already built)".format(shlib_ext))
+ 
+ 
+ def prebuild_libcsamtools(ext, force):
+@@ -589,10 +593,10 @@ modules = [
+          libraries=external_htslib_libraries),
+     dict(name="pysam.libcsamtools",
+          prebuild_func=prebuild_libcsamtools,
+-         sources=[source_pattern % "samtools"] + glob.glob(os.path.join("samtools", "*.pysam.c")) +
+-         [os.path.join("samtools", "lz4", "lz4.c")] + os_c_files,
++         sources=[source_pattern % "samtools"] + glob.glob(os.path.join("samtools", "*.pysam.c")) \
++         + os_c_files,
+          extra_objects=separate_htslib_objects,
+-         libraries=external_htslib_libraries + internal_htslib_libraries),
++         libraries=external_htslib_libraries + internal_htslib_libraries + ["lz4"]),
+     dict(name="pysam.libcbcftools",
+          sources=[source_pattern % "bcftools"] + glob.glob(os.path.join("bcftools", "*.pysam.c")) + os_c_files,
+          extra_objects=separate_htslib_objects,
+@@ -646,7 +650,7 @@ common_options = dict(
+     # for out-of-tree compilation, use absolute paths
+     library_dirs=[os.path.abspath(x) for x in ["pysam"] + htslib_library_dirs],
+     include_dirs=[os.path.abspath(x) for x in ["pysam"] + htslib_include_dirs + \
+-                  ["samtools", "samtools/lz4", "bcftools", "."] + include_os])
++                  ["samtools", "bcftools"] + include_os])
+ 
+ # add common options (in python >3.5, could use n = {**a, **b}
+ for module in modules:
+-- 
+2.43.0
+


### PR DESCRIPTION
pysam 0.22.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3785](https://anaconda.atlassian.net/browse/PKG-3785)
- [Upstream repository](https://github.com/pysam-developers/pysam/tree/v0.22.0)

### Explanation of changes:

This is the first build of pysam.

`pysam` vendors [htslib](https://github.com/samtools/htslib), [bcftools](https://github.com/samtools/bcftools) and [samtools](https://github.com/samtools/samtools). Both the vendored `bcftools` and `samtools` are modified from upstream. Because all three are tightly coupled and because two of them are modified, we (me and Cheng) decided to not unvendor them.

But I unvendored lz4 and made sure that we statically link all dependencies.

[PKG-3785]: https://anaconda.atlassian.net/browse/PKG-3785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ