### PR TITLE
pysam 0.22.1: build with libdeflate 1.22 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 upload_channels:
   - sfe1ed40
+
+channels:
+  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pysam" %}
-{% set version = "0.22.0" %}
+{% set version = "0.22.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pysam-developers/pysam/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 61b3377c5f889ddc6f6979912c3bb960d7e08407dada9cb38f13955564ea036f
+  sha256: e4981524d7627c53fa0d3f8cbec2bd65c2ea7520092f25e1029af12cb7b82ff6
   patches:
     - patches/0001-Unvendor-deps.patch
 
@@ -38,7 +38,7 @@ requirements:
     - libcurl 8
     - bzip2 {{ bzip2 }}
     - xz {{ xz }}
-    - libdeflate 1.17
+    - libdeflate 1.22
     # Only required for libcrypto.
     # On macOS, links to libSystem
     - openssl  {{ openssl }}  # [linux]


### PR DESCRIPTION
pysam 0.22.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6445](https://anaconda.atlassian.net/browse/PKG-6445)
- [Upstream repository](https://github.com/pysam-developers/pysam/tree/v0.22.1)
- Requirements: 
  - https://github.com/pysam-developers/pysam/blob/v0.22.1/pyproject.toml
  - https://github.com/pysam-developers/pysam/blob/v0.22.1/setup.py

### Explanation of changes:

- Pin ibdeflate to 1.22

### Notes

- https://github.com/AnacondaRecipes/libdeflate-feedstock/pull/6

[PKG-6445]: https://anaconda.atlassian.net/browse/PKG-6445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ